### PR TITLE
Updating the sache.json example file link to be an actual sache.json file

### DIFF
--- a/views/_modal.haml
+++ b/views/_modal.haml
@@ -21,7 +21,7 @@
                   "tags": ["ui", "buttons", "etc"]
                 }
         %p{:class => "note"}
-          %a{:href => "https://github.com/jhardy/omg-shadows/blob/master/sassmanifest.json", :target => "_blank"}
+          %a{:href => "https://github.com/jhardy/Sassy-Buttons/blob/master/sache.json", :target => "_blank"}
             Checkout a real live sache.json file &rarr;
       %li
         %p Enter your project SSH clone URL:


### PR DESCRIPTION
Currently the "Checkout a real live sache.json file" link points to a [sassmanifest.json](https://github.com/jhardy/omg-shadows/blob/master/sassmanifest.json) file.
It would be more helpful if it points to a [sache.json](https://github.com/jhardy/Sassy-Buttons/blob/master/sache.json) file.
